### PR TITLE
add reference to Evolution metric Issue Response Time

### DIFF
--- a/focus-areas/when/time-to-first-response.md
+++ b/focus-areas/when/time-to-first-response.md
@@ -22,6 +22,7 @@ Time to first response of an activity = time first response was posted to the ac
 
 * Role of responder, e.g., only count maintainer responses
 * Automated responses, e.g., only count replies from real people by filtering bots and other automated replies
+* Type of Activity, e.g., issues (see metric [Issue Response Time](https://github.com/chaoss/wg-evolution/blob/master/metrics/Issue_Response_Time.md)), emails, chat, code reviews
 
 
 ### Visualizations


### PR DESCRIPTION
During the release, we discovered that the Evolution metric Issue Response time was very similar to the Common metric Time to First Response. From this realization, during the Evolution WG meeting today, we propose to add a filter to Time to First Response based on the `Type of Activity`, so that the Issue Response time is an implementation.