### PR TITLE
Add Types of Contributions metric to "What"

### DIFF
--- a/focus-areas/what/README.md
+++ b/focus-areas/what/README.md
@@ -4,4 +4,4 @@ Goal: Understand what contributions organizations and people are being made.
 
 Metric | Question
 --- | ---
-[Holder]() | Question?
+[Types of Contributions](types-of-contributions.md) | What types of contributions are being made?

--- a/focus-areas/what/types-of-contributions.md
+++ b/focus-areas/what/types-of-contributions.md
@@ -1,0 +1,66 @@
+# Types of Contributions
+Question: What types of contributions are being made?
+## Description
+
+Multiple, varied contributions make an open source project healthy. Many projects have community members who do not write code but contribute in equally valuable ways by managing the community, triaging bugs, evangelizing the project, supporting users, or helping in other ways. 
+## Objectives
+
+A variety of contribution types can demonstrate that a project is mature and well-rounded with sufficient activity to support all aspects of the project, and enable paths to leadership that are supportive of a variety of contribution types and people with varying expertise beyond coding.
+## Implementation
+
+How contributions are defined, quantified, tracked and made public is a challenging question. Answers may be unique to each project and the following suggestions are a starting point. As a general guideline, it is difficult to compare different contribution types with each other and they might better be recognized independently. 
+
+- The following list can help with identifying contribution types:
+  * Coding (can be separated further, e.g., front-end vs. backend)
+  * Bug Triaging
+  * Quality Assurance and Testing
+  * Security-Related Activities
+  * Localization/L10N and Translation
+  * Event Organization
+  * Documentation Authorship
+  * Community Building and Management
+  * Teaching and Tutorial Building
+  * Troubleshooting and Support
+  * Creative Work and Design
+  * User Interface, User Experience, and Accessibility
+  * Social Media Management
+  * User Support and Answering Questions
+  * Writing Articles
+  * Public Relations - Interviews with Technical Press
+  * Speaking at Events
+  * Marketing and Campaign Advocacy
+  * Website Development 
+  * Legal Council 
+  * Financial Management
+
+### Data Collection Strategies
+
+- **Interview or Survey:** Ask community members to recognize others for their contributions to recognize contribution types that have previously not been considered.
+  * Who in the project would you like to recognize for their contributions? What did they contribute?
+
+- **Observe project:** Identify and recognize leads of different parts of the project.
+  * What leaders are listed on the project website or in a repository?
+
+- **Capture Non-code Contributions:** Track contributions through a dedicated system, e.g., an issue tracker.
+  * Logging can include custom information a project wants to know about non-code contributions to recognize efforts.
+  * Proxy contributions through communication channel activity. For example, If quality assurance members (QA) have their own mailing list, then activity around QA contributions can be measured by proxy from mailing list activity.
+
+- **Collect Trace Data:** Measure contributions through collaboration tool log data.
+  * For example, code contributions can be counted from a source code repository, wiki contributions can be counted from a wiki edit history, and email messages can be counted from an email archive 
+
+- **Automate Classification:** Train an artificial intelligence (AI) bot to detect and classify contributions.
+  * An AI bot can assist in categorizing contributions, for example, help requests vs. support provided, or feature request vs. bug reporting, especially if these are all done in the same issue tracker.
+
+_Other considerations:_
+
+- Especially with automated reports, allow community members to opt-out and not appear on the contribution reports.
+- Acknowledge imperfect capture of contribution types and be explicit about what types of contributions are included.
+- As a project evolves, methods for collecting types of contributions will need to adapt. For example, when an internationalization library is exchanged, project activity around localization conceivably produces different metrics before and after the change.
+- Account for activity from bots when mining contribution types at large scale.
+
+## References
+- https://medium.com/@sunnydeveloper/revisiting-the-word-recognition-in-foss-and-the-dream-of-open-credentials-d15385d49447 
+- https://24pullrequests.com/contributing 
+- https://smartbear.com/blog/test-and-monitor/14-ways-to-contribute-to-open-source-without-being/ 
+- https://wiki.openstack.org/wiki/AUCRecognition
+- https://www.drupal.org/drupalorg/blog/a-guide-to-issue-credits-and-the-drupal.org-marketplace


### PR DESCRIPTION
This metric came originally out of the D&I working group. We removed the D&I related aspects and focused on the technical parts of "how to collect metrics about types of contributions". 

Revised on the Common WG call today with @geekygirldawn, @sgoggins, @germonprez, and @GeorgLink 

close #40 