### PR TITLE
add filter "project segement" to "Date and Time" metric

### DIFF
--- a/focus-areas/when/activity-dates-and-times.md
+++ b/focus-areas/when/activity-dates-and-times.md
@@ -20,6 +20,7 @@ Individuals engage in activities in open source projects at various times of the
 * Aggregation of time by local time
   - Can show what times of day in their local times they contribute. Conclusions about the If contributions are more during working hours, or if contributions are more during evening hours.
 * Repository ID
+* Segement of a community, (e.g., GrimoireLab has more EU TimeZone activity and Augur more US Timezones activity)
 
 ### Visualizations
 

--- a/focus-areas/when/activity-dates-and-times.md
+++ b/focus-areas/when/activity-dates-and-times.md
@@ -20,7 +20,7 @@ Individuals engage in activities in open source projects at various times of the
 * Aggregation of time by local time
   - Can show what times of day in their local times they contribute. Conclusions about the If contributions are more during working hours, or if contributions are more during evening hours.
 * Repository ID
-* Segement of a community, (e.g., GrimoireLab has more EU TimeZone activity and Augur more US Timezones activity)
+* Segment of a community, (e.g., GrimoireLab has more EU time zones activity and Augur more US time zones activity)
 
 ### Visualizations
 


### PR DESCRIPTION
This PR adds a filter "Project segments" to the Date and Time metric.

For example, when we look at activity in the CHAOSS project, we have a lot of activity in US and EU timezones, but when filtering by Augur and GrimoireLab (i.e., project segment) we see that Augur is US Timezone heavy and GrimoireLab is EU Timezone heavy.

Inspired by #31