### PR TITLE
Fixing minor issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 This document outlines a generic process of contributing and applies to all CHAOSS repositories. Each repository may have unique guidelines specific to the project.
 
-* Metrics definition. For each metric, we have a document describing it,
-all of them in the [metrics directory](metrics).
+* Metrics definition. For each metric, we have a document describing it.
+The metrics are organized into various [focus-areas](focus-areas).
 You can contribute by helping to refine those metrics definitions.
 
 ## Where can I contribute?

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ We are involved in the release of CHAOSS metrics. Check out our published work a
 
 Focus Area | Goal
 --- | ---
-[Who](./focus-areas/who) | Understand organizational and personal engagement with open source projects. 
-[What](./focus-areas/what) | Understand what contributions organizations and people are being made.
-[When](./focus-areas/when) | Understand when contributions from organizations and people are happening. 
-[Where](./focus-areas/where) | Understand where contributions from organizations and people are happening. 
+[Who](focus-areas/who) | Understand organizational and personal engagement with open source projects. 
+[What](focus-areas/what) | Understand what contributions organizations and people are being made.
+[When](focus-areas/when) | Understand when contributions from organizations and people are happening. 
+[Where](focus-areas/where) | Understand where contributions from organizations and people are happening. 
 
 
 ## Contributors


### PR DESCRIPTION
This PR fixes the following issues -

1. Replaced the dot-slash notation to focus-areas in the main [README](https://github.com/chaoss/wg-common/blob/master/README.md), to maintain the consistency across all Working Groups
2. The metrics directory was removed recently, but [CONTRIBUTING.md](https://github.com/chaoss/wg-common/blob/master/CONTRIBUTING.md) still contains stale link to it, replaced it with focus-areas link