### PR TITLE
standardize focus-areas READMEs

### DIFF
--- a/focus-areas/README.md
+++ b/focus-areas/README.md
@@ -1,10 +1,10 @@
 # Focus Areas
 
-The common metrics dealt with in this working group are organized in focus areas:
+The common metrics are organized in focus areas:
 
-Focus Area | Goal
---- | ---
-[What](./what) | Identify what contributions were made (e.g., code commit, wiki edit).   
-[Who](./who) | Identify metrics about individuals or organizations who made contributions (e.g., location, age).
-[When](./when) | Identify when contributions occurred (e.g., time to respond).
-[Where](./where) | Where in the project contributions occurred (e.g., GitHub, documentation).
+| Focus Area | Goal |
+| --- | --- |
+| [What](what) | Identify what contributions were made (e.g., code commit, wiki edit). |
+| [When](when) | Identify when contributions occurred (e.g., time to respond). |
+| [Where](where) | Where in the project contributions occurred (e.g., GitHub, documentation). |
+| [Who](who) | Identify metrics about individuals or organizations who made contributions (e.g., location, age). |

--- a/focus-areas/what/README.md
+++ b/focus-areas/what/README.md
@@ -1,8 +1,8 @@
+## What
 
-Goal: Understand what contributions organizations and people are being made.
+**Goal:** Understand what contributions organizations and people are being made.
 
-
-Metric | Question
---- | ---
-[Types of Contributions](types-of-contributions.md) | What types of contributions are being made?
-[Technical Fork](technical-fork.md)| What are a number of technical forks of an open source project on code development platforms?
+| Metric | Question |
+| --- | --- |
+| [Technical Fork](technical-fork.md)| What are a number of technical forks of an open source project on code development platforms? |
+| [Types of Contributions](types-of-contributions.md) | What types of contributions are being made? |

--- a/focus-areas/when/README.md
+++ b/focus-areas/when/README.md
@@ -1,11 +1,11 @@
+## When
 
-Goal: Understand when contributions from organizations and people are happening.
+**Goal:** Understand when contributions from organizations and people are happening.
 
-
-Metric | Question
---- | ---
-[Activity Dates and Times](activity-dates-and-times.md) | What are the dates and timestamps of when contributor activities occur?
-[Burstiness](burstiness.md) | How are short timeframes of intense activity, followed by a corresponding return to a typical pattern of activity, observed in a project?
-[Review Cycle Duration within a Change Request](review-cycle-duration-within-a-change-request.md) | What is the duration of a review cycle within a single change request?
-[Time to First Response](time-to-first-response.md) | How much time passes between when an activity requiring attention is created and the first response?
-[Time to Close](time-to-close.md) | How much time passes between creating and closing an operation such as an issue, review, or support ticket?  
+| Metric | Question |
+| --- | --- |
+| [Activity Dates and Times](activity-dates-and-times.md) | What are the dates and timestamps of when contributor activities occur? |
+| [Burstiness](burstiness.md) | How are short timeframes of intense activity, followed by a corresponding return to a typical pattern of activity, observed in a project? |
+|[Review Cycle Duration within a Change Request](review-cycle-duration-within-a-change-request.md) | What is the duration of a review cycle within a single change request? |
+| [Time to Close](time-to-close.md) | How much time passes between creating and closing an operation such as an issue, review, or support ticket? |
+| [Time to First Response](time-to-first-response.md) | How much time passes between when an activity requiring attention is created and the first response? |

--- a/focus-areas/where/README.md
+++ b/focus-areas/where/README.md
@@ -1,7 +1,7 @@
+## Where
 
-Goal: Understand where contributions from organizations and people are happening.
+**Goal:** Understand where contributions from organizations and people are happening.
 
-
-Metric | Question
---- | ---
-Holder | Question?
+| Metric | Question |
+| --- | --- |
+| Holder | Question? |

--- a/focus-areas/who/README.md
+++ b/focus-areas/who/README.md
@@ -1,21 +1,20 @@
 ## Who
 
-Goal: Understand organizational and personal engagement with open source projects.
+**Goal:** Understand organizational and personal engagement with open source projects.
 
-
-Metric | Question
---- | ---
-[Contributors](contributors.md) | Who are the contributors to a project?
-[Contributor Location](contributor-location.md) | What is the location of contributors?
-[Organizational Diversity](organizational-diversity.md) | What is the organizational diversity of contributions?
-Organizational Influence | How dominant are individual organizations in a project?
-Organizational Relationships | How do organizational partnerships / collaborations impact the project?
-Contributor Affiliation Changes | What are the impact of job changes (organizational affiliation changes) on a project?
-Organizations Contributing (Joining and leaving) | What is the impact of organizations joining or leaving the project
-Organization or volunteer driven | What is organizational affiliation vs. non-organizational affiliation?
-Peripheral Organizations | Who are the drive-by organizational contributors?
-Leadership Organizational Affiliation | How are leadership positions distributed across organizations?
-Financial Considerations | How do financial considerations impact the projects?
-Organizational Ownership Distribution | How is code ownership distributed across organizational and non-organizational contributors?
-Contributor Country | What is the primary residence of the contributor?
-Contributor Employer Country | What is the headquarters location of the organization employing the contributor if they are contributing on behalf of their employer?
+| Metric | Question |
+| --- | --- |
+| [Contributor Location](contributor-location.md) | What is the location of contributors? |
+| [Contributors](contributors.md) | Who are the contributors to a project? |
+| [Organizational Diversity](organizational-diversity.md) | What is the organizational diversity of contributions? |
+| Organizational Influence | How dominant are individual organizations in a project? |
+| Organizational Relationships | How do organizational partnerships / collaborations impact the project? |
+| Contributor Affiliation Changes | What are the impact of job changes (organizational affiliation changes) on a project? |
+| Organizations Contributing (Joining and leaving) | What is the impact of organizations joining or leaving the project |
+| Organization or volunteer driven | What is organizational affiliation vs. non-organizational affiliation? |
+| Peripheral Organizations | Who are the drive-by organizational contributors? |
+| Leadership Organizational Affiliation | How are leadership positions distributed across organizations? |
+| Financial Considerations | How do financial considerations impact the projects? |
+| Organizational Ownership Distribution | How is code ownership distributed across organizational and non-organizational contributors? |
+| Contributor Country | What is the primary residence of the contributor? |
+| Contributor Employer Country | What is the headquarters location of the organization employing the contributor if they are contributing on behalf of their employer? |


### PR DESCRIPTION
This PR addresses the issue of Standardizing READMEs for:
1. focus-areas/README.md
2. focus-areas/*\<focus-area>*/README.md

The issue can be found [here](https://github.com/chaoss/governance/issues/276), and the doc for template can be found [here](https://docs.google.com/document/d/12cac1TA_xTpUCcoTWg3e_03-m22CjLelTioaXRrTnpo/edit?usp=sharing)

Updates done:
* Added specific relative path format for pointing to the focus-areas as well as the metrics
* Added subheading in for each focus-area
* Reordered the focus-areas and metrics listed in the tables in lexicographical order to match the way github displays those files and folders

Signed-off-by: ritik-malik <ritik18406@iiitd.ac.in>