### PR TITLE
Add empty lines to correct markdown formatting

### DIFF
--- a/focus-areas/when/time-to-first-response.md
+++ b/focus-areas/when/time-to-first-response.md
@@ -26,11 +26,17 @@ Time to first response of an activity = time first response was posted to the ac
 
 
 ### Visualizations
+
 ![GrimoireLab Panel: Efficiency Timing Overview](images/time-to-first-response_efficiency-timing-overview.png)
+
 ---------
+
 ![Augur Visualization: Time to First Response Heat Map ](images/time-to-first-response_augur-ttc-1.png)
+
 ---------
+
 ![Augur Visualization: Mean Response Times](images/time-to-first-response_augur-ttc-2.png)
+
 
 ### Tools Providing the Metric
 


### PR DESCRIPTION
The images were identified as headings. Adding the 
empty lines turn the hyphens into horizontal lines.