### PR TITLE
Renaming programing language metric

### DIFF
--- a/focus-areas/contributions/README.md
+++ b/focus-areas/contributions/README.md
@@ -6,6 +6,6 @@
 | --- | --- |
 | [Technical Fork](technical-fork.md)| What are a number of technical forks of an open source project on code development platforms? |
 | [Types of Contributions](types-of-contributions.md) | What types of contributions are being made? |
-| [Programming Language Distribution](language-distribution.md) | What are the different programming languages present in an open source project(s), and what is the percentage of each language?  |
+| [Programming Language Distribution](programming-language-distribution.md) | What are the different programming languages present in an open source project(s), and what is the percentage of each language?  |
 | [Clones](clones.md) | How many copies of an open source project repository have been saved on a local machine?  |
 

--- a/focus-areas/contributions/programming-language-distribution.md
+++ b/focus-areas/contributions/programming-language-distribution.md
@@ -1,7 +1,5 @@
 # Programming Language Distribution
 
-### This metric is a release candidate. To comment on this metric please see Issue #[131](https://github.com/chaoss/wg-common/issues/131). Following a comment period, this metric will be included in the next regular release.
-
 Question: What are the different programming languages present in an open source project(s), and what is the percentage of each language?
 
 ## Description


### PR DESCRIPTION
Renaming language-distribution.md to programming-language-distribution. 

Signed-off-by: Vinod K. Ahuja <vahuja@unomaha.edu>