### PR TITLE
Update release-frequency.md

### DIFF
--- a/focus-areas/time/release-frequency.md
+++ b/focus-areas/time/release-frequency.md
@@ -2,10 +2,6 @@
 
 Question: How often does a project publish a release of their software / artifact?
 
-Context Tags: Lifecycle (Time/Duration), Software
-
-Keywords: release, bug fixes, security, version, release cycle, cadence
-
 ## Description
 The frequency of project software / artifact releases over time. This includes the major releases and smaller point releases that might contain bug fixes and security updates. 
 
@@ -54,5 +50,3 @@ In many cases, this data can be collected from the same platform as the source c
 - Matt Germonprez
 - Vinod Ahuja
 - Kevin Lumbard
-
-*The usage and dissemination of health metrics may lead to privacy violations. Organizations may be exposed to risks. These risks may flow from compliance with the GDPR in the EU, with state law in the US, or with other laws. There may also be contractual risks flowing from terms of service for data providers such as GitHub and GitLab. The usage of metrics must be examined for risk and potential data ethics problems. Please see [CHAOSS Data Ethics document](https://github.com/chaoss/community/blob/main/data-use-statement.md) for additional guidance.* 


### PR DESCRIPTION
Removing data ethics statement from the text in favor of using wordpress to include the statement on all docs.

Also removed keywords and context tags as they will be included in WP.

Signed-off-by: Matt Germonprez <germonprez@gmail.com>

